### PR TITLE
刪除多的 router 路徑及元件，微調路徑名稱及更新元件中的連結

### DIFF
--- a/src/components/CleanBeanList.vue
+++ b/src/components/CleanBeanList.vue
@@ -91,7 +91,7 @@ export default {
   components: { Roast, Draggable, DelConfirm },
   methods: {
     editProduct(item) {
-      this.$router.push(`/m-admin/products/edit/${item.id}`);
+      this.$router.push(`/admin/products/edit/${item.id}`);
     },
     openDelConfirm(item) {
       this.$refs.delConfirm.openConfirm(item);

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,7 +2,7 @@ import { createRouter, createWebHashHistory } from "vue-router";
 
 const routes = [
   {
-    path: "/m-admin",
+    path: "/admin",
     component: () => import("@/views/Manager/Root.vue"),
     children: [
       {
@@ -18,18 +18,6 @@ const routes = [
         component: () => import("@/views/Manager/EditProduct.vue"),
       },
     ],
-  },
-  {
-    path: "/admin",
-    component: () => import("@/views/Manager/Home.vue"),
-  },
-  {
-    path: "/admin/products/new",
-    component: () => import("@/views/Manager/AddProduct.vue"),
-  },
-  {
-    path: "/admin/products/edit/:productId",
-    component: () => import("@/views/Manager/EditProduct.vue"),
   },
   {
     path: "/",

--- a/src/views/Manager/AddProduct.vue
+++ b/src/views/Manager/AddProduct.vue
@@ -26,7 +26,7 @@ export default {
         .then((response) => {
           if (response.status === 200) {
             this.showSuccessToast("新增成功");
-            this.$router.push("/m-admin/products");
+            this.$router.push("/admin/products");
           }
         })
         .catch((error) => {

--- a/src/views/Manager/EditProduct.vue
+++ b/src/views/Manager/EditProduct.vue
@@ -43,7 +43,7 @@ export default {
         .then((response) => {
           if (response.status === 200) {
             this.showSuccessToast("編輯成功");
-            this.$router.push("/m-admin/products");
+            this.$router.push("/admin/products");
           }
         })
         .catch((error) => {

--- a/src/views/Manager/Home.vue
+++ b/src/views/Manager/Home.vue
@@ -45,7 +45,7 @@ export default {
         });
     },
     toAddProduct() {
-      this.$router.push("/m-admin/products/new");
+      this.$router.push("/admin/products/new");
     },
   },
   created() {

--- a/src/views/Manager/Navbar.vue
+++ b/src/views/Manager/Navbar.vue
@@ -19,7 +19,7 @@
           >
           </Button>
         </router-link>
-        <router-link v-if="token" to="/m-admin/products" class="link-content">
+        <router-link v-if="token" to="/admin/products" class="link-content">
           <Button icon="pi pi-fw pi-user" class="p-button-text p-button-plain">
           </Button>
         </router-link>
@@ -38,7 +38,7 @@ export default {
         {
           label: "豆單",
           icon: "pi pi-fw pi-book",
-          to: "/m-admin/products",
+          to: "/admin/products",
         },
       ],
       visibleRight: false,


### PR DESCRIPTION
https://kakas-redmine.herokuapp.com/issues/997

##  整理管理者的 router 
###  1.   /m-admin 改為 /admin
###  2.   把多餘的 /admin 相關的路徑及元件刪除
###  3.   更新元件中有 /m-admin 的連結