### PR TITLE
Feature/ UI - 商品詳細資訊頁面要讓使用者設定咖啡為「原豆」或「磨粉」 ( grinding options )

### DIFF
--- a/src/components/ProductDetail.vue
+++ b/src/components/ProductDetail.vue
@@ -7,7 +7,7 @@
       <div class="p-grid p-px-3">
         <h3 class="p-col-12">{{ product.name }}</h3>
         <div class="p-col-12 p-text-bold price-size">NT$ {{ unitPrice }}</div>
-        <div class="p-col-12 p-mt-7">
+        <div v-if="type_is_bounds" class="p-col-12 p-mt-7">
           <SelectButton
             v-model="ground"
             :options="groundOfOptions"
@@ -99,7 +99,7 @@ export default {
       ],
       qty: 1,
       type: "half_pound",
-      ground: false,
+      ground: true,
       is_error: false,
     };
   },
@@ -195,6 +195,13 @@ export default {
         price = this.product.one_pound_price;
       }
       return price;
+    },
+    type_is_bounds() {
+      let isBounds = true;
+      if (this.type === "drip_bag") {
+        isBounds = false;
+      }
+      return isBounds;
     },
   },
   created() {

--- a/src/components/ProductDetail.vue
+++ b/src/components/ProductDetail.vue
@@ -89,9 +89,9 @@ export default {
         roast: 1,
       },
       typeOfOptions: [
-        { value: "drip_bag", label: "耳掛" },
         { value: "half_pound", label: "半磅" },
         { value: "one_pound", label: "一磅" },
+        { value: "drip_bag", label: "耳掛" },
       ],
       groundOfOptions: [
         { value: true, label: "磨粉" },

--- a/src/components/ProductDetail.vue
+++ b/src/components/ProductDetail.vue
@@ -9,6 +9,15 @@
         <div class="p-col-12 p-text-bold price-size">NT$ {{ unitPrice }}</div>
         <div class="p-col-12 p-mt-7">
           <SelectButton
+            v-model="ground"
+            :options="groundOfOptions"
+            optionValue="value"
+            optionLabel="label"
+            class="selected"
+          />
+        </div>
+        <div class="p-col-12 p-mt-7 p-pt-0">
+          <SelectButton
             v-model="type"
             :options="typeOfOptions"
             optionValue="value"
@@ -84,8 +93,13 @@ export default {
         { value: "half_pound", label: "半磅" },
         { value: "one_pound", label: "一磅" },
       ],
+      groundOfOptions: [
+        { value: true, label: "磨粉" },
+        { value: false, label: "原豆" },
+      ],
       qty: 1,
       type: "half_pound",
+      ground: false,
       is_error: false,
     };
   },

--- a/src/components/ProductDetail.vue
+++ b/src/components/ProductDetail.vue
@@ -122,6 +122,7 @@ export default {
         product_id: this.product.id,
         package_type: this.type,
         quantity: this.qty,
+        ground: this.ground,
       };
       const api = `${process.env.VUE_APP_API}/users/cart_items`;
       const headers = { Authorization: Cookies.get("lemonToken") };

--- a/src/components/ProductDetail.vue
+++ b/src/components/ProductDetail.vue
@@ -7,7 +7,7 @@
       <div class="p-grid p-px-3">
         <h3 class="p-col-12">{{ product.name }}</h3>
         <div class="p-col-12 p-text-bold price-size">NT$ {{ unitPrice }}</div>
-        <div v-if="type_is_bounds" class="p-col-12 p-mt-7">
+        <div v-if="isShowBroundOption" class="p-col-12 p-mt-7">
           <SelectButton
             v-model="ground"
             :options="groundOfOptions"
@@ -197,12 +197,8 @@ export default {
       }
       return price;
     },
-    type_is_bounds() {
-      let isBounds = true;
-      if (this.type === "drip_bag") {
-        isBounds = false;
-      }
-      return isBounds;
+    isShowBroundOption() {
+      return this.type !== "drip_bag";
     },
   },
   created() {

--- a/src/components/ProductDetail.vue
+++ b/src/components/ProductDetail.vue
@@ -7,7 +7,7 @@
       <div class="p-grid p-px-3">
         <h3 class="p-col-12">{{ product.name }}</h3>
         <div class="p-col-12 p-text-bold price-size">NT$ {{ unitPrice }}</div>
-        <div v-if="isShowBroundOption" class="p-col-12 p-mt-7">
+        <div v-if="isShowGroundOption" class="p-col-12 p-mt-7">
           <SelectButton
             v-model="ground"
             :options="groundOfOptions"
@@ -200,7 +200,7 @@ export default {
       }
       return price;
     },
-    isShowBroundOption() {
+    isShowGroundOption() {
       return this.type !== "drip_bag";
     },
   },

--- a/src/components/ProductDetail.vue
+++ b/src/components/ProductDetail.vue
@@ -118,6 +118,9 @@ export default {
         });
     },
     addToCart() {
+      if (this.type === "drip_bag") {
+        this.ground = true;
+      }
       const cart = {
         product_id: this.product.id,
         package_type: this.type,


### PR DESCRIPTION
https://kakas-redmine.herokuapp.com/issues/1022
## 在 /products/:id ( 元件 : ProductDetail.vue ) 加上「原豆」或「磨粉」選項的 UI
## ★ 電腦版
![image](https://user-images.githubusercontent.com/77562017/150901930-b231b5bd-2bed-414a-81ed-2259d379dc6e.png)
## ★ 手機版
![image](https://user-images.githubusercontent.com/77562017/150901980-c22d1182-c23d-4372-945c-7db99be7ae4b.png)
## ★ 選耳掛不會出現是否磨粉選項
![image](https://user-images.githubusercontent.com/77562017/150902197-92ffe231-5df2-4ded-8945-a36f023dc813.png)
