### PR TITLE
Feature/ 串接 /admin/orders API ( link orders api )

### DIFF
--- a/src/components/OrderStatus.vue
+++ b/src/components/OrderStatus.vue
@@ -9,7 +9,7 @@
 
     <Button
       @click.prevent="confirm_order"
-      v-if="the_order.status === 'pending'"
+      v-if="the_order['may_confirm?']"
       label="確認訂單"
       class="
         p-button-raised p-button-info p-button-sm p-lg-fixed p-col-3 p-px-2

--- a/src/components/OrderStatus.vue
+++ b/src/components/OrderStatus.vue
@@ -50,7 +50,7 @@ export default {
         .put(api, data, { headers })
         .then((response) => {
           this.the_order = response.data;
-          this.emitter.emit("updateOrderStatus");
+          this.emitter.emit("updateOrderAllStatus");
         })
         .catch((error) => {
           if (error.response.status === 401) {

--- a/src/components/OrderStatus.vue
+++ b/src/components/OrderStatus.vue
@@ -26,16 +26,38 @@
 </template>
 
 <script>
+import axios from "axios";
+import Cookies from "js-cookie";
 export default {
   props: {
-    orderStatus: {
-      type: String,
+    orderData: {
+      type: Object,
+    },
+  },
     },
   },
   inject: ["emitter"],
   methods: {
     confirm_order() {
-      this.emitter.emit("update_order_status", "confirmed");
+      const api = `${process.env.VUE_APP_API}/admin/orders/${this.orderData.id}/status`;
+      const headers = { Authorization: Cookies.get("lemonToken") };
+      const data = { status: "confirmed" };
+      axios
+        .put(api, data, { headers })
+        .then((response) => {
+          console.log(response);
+        })
+        .catch((error) => {
+          if (error.response.status === 401) {
+            Cookies.remove("lemonToken");
+            this.showErrorToast("請重新登入");
+            this.$router.push("/entrance/login");
+          }
+        })
+        .finally(() => {
+          this.loading = false;
+        });
+    },
     },
   },
   computed: {

--- a/src/components/Orders.vue
+++ b/src/components/Orders.vue
@@ -19,7 +19,7 @@
     stateKey="dt-state-demo-local"
     v-model:selection="orders.items"
     selectionMode="single"
-    @rowSelect="openTheOrder(orders.items)"
+    @rowSelect="getTheOrder(orders.items.id)"
   >
     <template #header>
       <div class="p-text-center">
@@ -185,8 +185,24 @@ export default {
           return "已取貨";
       }
     },
-    openTheOrder(the_order) {
-      this.order = { ...the_order };
+    getTheOrder(id) {
+      const api = `${process.env.VUE_APP_API}/admin/orders/${id}`;
+      const headers = { Authorization: Cookies.get("lemonToken") };
+      axios
+        .get(api, { headers })
+        .then((response) => {
+          this.order = { ...response.data };
+        })
+        .catch((error) => {
+          if (error.response.status === 401) {
+            Cookies.remove("lemonToken");
+            this.showErrorToast("請重新登入");
+            this.$router.push("/entrance/login");
+          }
+        })
+        .finally(() => {
+          this.loading = false;
+        });
     },
   },
   created() {

--- a/src/components/Orders.vue
+++ b/src/components/Orders.vue
@@ -107,6 +107,7 @@ export default {
     };
   },
   components: { UserSingleOrder },
+  inject: ["emitter"],
   methods: {
     getOrders() {
       const api = `${process.env.VUE_APP_API}/users/orders`;
@@ -207,6 +208,9 @@ export default {
   },
   created() {
     this.getOrders();
+    this.emitter.on("updateUserOrderAllStatus", () => {
+      this.getOrders();
+    });
   },
 };
 </script>

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -108,6 +108,7 @@ export default {
         .then((response) => {
           this.the_order = response.data;
           this.emitter.emit("updateOrderAllStatus");
+          this.emitter.emit("updateCancelBtnStatus", this.the_order.id);
         })
         .catch((error) => {
           if (error.response.status === 401) {

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -129,7 +129,25 @@ export default {
         });
     },
     confirm_picked_up() {
-      this.emitter.emit("update_shipping_status", "picked_up");
+      const api = `${process.env.VUE_APP_API}/admin/orders/${this.the_order.id}/shipping_status`;
+      const headers = { Authorization: Cookies.get("lemonToken") };
+      const data = { shipping_status: "picked_up" };
+      axios
+        .put(api, data, { headers })
+        .then((response) => {
+          this.the_order = response.data;
+          this.emitter.emit("updateOrderAllStatus");
+        })
+        .catch((error) => {
+          if (error.response.status === 401) {
+            Cookies.remove("lemonToken");
+            this.showErrorToast("請重新登入");
+            this.$router.push("/entrance/login");
+          }
+        })
+        .finally(() => {
+          this.loading = false;
+        });
     },
   },
   computed: {

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -8,7 +8,7 @@
     <i class="pi pi-arrow-right p-mx-1"></i>
     <Button
       @click="confirm_shipped"
-      v-if="in_preparation"
+      v-if="the_order['may_to_shipping?']"
       label="確認發貨"
       class="
         p-button-raised p-button-info p-button-sm p-lg-fixed p-col-2 p-px-2

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -134,42 +134,38 @@ export default {
     },
   },
   computed: {
+    shipping() {
+      return this.the_order.shipping_status === "shipping";
+    },
+    arrived() {
+      return this.the_order.shipping_status === "arrived";
+    },
     picked_up() {
       return this.the_order.shipping_status === "picked_up";
     },
     arrived_style() {
-      if (
-        this.the_order.shipping_status === "arrived" ||
-        this.the_order.shipping_status === "picked_up"
-      ) {
+      if (this.arrived || this.picked_up) {
         return "progress-color";
       } else {
         return "disabled-color";
       }
     },
     shipping_arrow_style() {
-      if (
-        this.the_order.shipping_status === "shipping" ||
-        this.the_order.shipping_status === "arrived" ||
-        this.the_order.shipping_status === "picked_up"
-      ) {
+      if (this.shipping || this.arrived || this.picked_up) {
         return "arrow-color";
       } else {
         return "disabled-color";
       }
     },
     arrived_arrow_style() {
-      if (
-        this.the_order.shipping_status === "arrived" ||
-        this.the_order.shipping_status === "picked_up"
-      ) {
+      if (this.arrived || this.picked_up) {
         return "arrow-color";
       } else {
         return "disabled-color";
       }
     },
     picked_up_style() {
-      if (this.the_order.shipping_status === "picked_up") {
+      if (this.picked_up) {
         return "success-color";
       } else {
         return "disabled-color";

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -41,7 +41,7 @@
 
     <Button
       @click="confirm_picked_up"
-      v-if="arrived"
+      v-if="the_order['may_to_picked_up?']"
       label="確認取貨"
       class="
         p-button-raised p-button-info p-button-sm p-lg-fixed p-col-3 p-px-2

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -108,7 +108,25 @@ export default {
         });
     },
     confirm_arrived() {
-      this.emitter.emit("update_shipping_status", "arrived");
+      const api = `${process.env.VUE_APP_API}/admin/orders/${this.the_order.id}/shipping_status`;
+      const headers = { Authorization: Cookies.get("lemonToken") };
+      const data = { shipping_status: "arrived" };
+      axios
+        .put(api, data, { headers })
+        .then((response) => {
+          this.the_order = response.data;
+          this.emitter.emit("updateOrderAllStatus");
+        })
+        .catch((error) => {
+          if (error.response.status === 401) {
+            Cookies.remove("lemonToken");
+            this.showErrorToast("請重新登入");
+            this.$router.push("/entrance/login");
+          }
+        })
+        .finally(() => {
+          this.loading = false;
+        });
     },
     confirm_picked_up() {
       this.emitter.emit("update_shipping_status", "picked_up");

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -76,12 +76,6 @@ export default {
         return;
       },
     },
-    orderStatus: {
-      type: String,
-      default() {
-        return;
-      },
-    },
   },
 
   inject: ["emitter"],
@@ -192,7 +186,7 @@ export default {
       }
     },
     canceled() {
-      return this.orderStatus === "canceled";
+      return this.the_order.status === "canceled";
     },
   },
   watch: {

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -23,7 +23,7 @@
 
     <Button
       @click="confirm_arrived"
-      v-if="shipping"
+      v-if="the_order['may_to_arrived?']"
       label="確認到達"
       class="
         p-button-raised p-button-info p-button-sm p-lg-fixed p-col-2 p-px-2

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -15,7 +15,14 @@
       "
       style="width: 100px"
     />
-    <strong v-if="shipping || arrived || picked_up" class="progress-color">
+    <strong
+      v-if="
+        the_order['may_to_arrived?'] ||
+        the_order['may_to_picked_up?'] ||
+        the_order['may_finish?']
+      "
+      class="progress-color"
+    >
       已發貨
     </strong>
 
@@ -31,7 +38,11 @@
       style="width: 100px"
     />
     <strong
-      v-if="in_preparation || arrived || picked_up"
+      v-if="
+        the_order['may_to_shipping?'] ||
+        the_order['may_to_picked_up?'] ||
+        the_order['may_finish?']
+      "
       :class="arrived_style"
     >
       已到達
@@ -50,12 +61,20 @@
     />
 
     <strong
-      v-if="in_preparation || shipping || picked_up"
+      v-if="
+        the_order['may_to_shipping?'] ||
+        the_order['may_to_arrived?'] ||
+        the_order['may_finish?']
+      "
       :class="picked_up_style"
     >
       已取貨
     </strong>
-    <i v-if="picked_up" class="pi pi-check-circle success-color p-ml-1"> </i>
+    <i
+      v-if="the_order['may_finish?']"
+      class="pi pi-check-circle success-color p-ml-1"
+    >
+    </i>
   </div>
 </template>
 
@@ -148,38 +167,39 @@ export default {
     in_preparation() {
       return this.the_order.shipping_status === "in_preparation";
     },
-    shipping() {
-      return this.the_order.shipping_status === "shipping";
-    },
-    arrived() {
-      return this.the_order.shipping_status === "arrived";
-    },
-    picked_up() {
-      return this.the_order.shipping_status === "picked_up";
-    },
     arrived_style() {
-      if (this.arrived || this.picked_up) {
+      if (
+        this.the_order["may_to_picked_up?"] ||
+        this.the_order["may_finish?"]
+      ) {
         return "progress-color";
       } else {
         return "disabled-color";
       }
     },
     shipping_arrow_style() {
-      if (this.shipping || this.arrived || this.picked_up) {
+      if (
+        this.the_order["may_to_arrived?"] ||
+        this.the_order["may_to_picked_up?"] ||
+        this.the_order["may_finish?"]
+      ) {
         return "arrow-color";
       } else {
         return "disabled-color";
       }
     },
     arrived_arrow_style() {
-      if (this.arrived || this.picked_up) {
+      if (
+        this.the_order["may_to_picked_up?"] ||
+        this.the_order["may_finish?"]
+      ) {
         return "arrow-color";
       } else {
         return "disabled-color";
       }
     },
     picked_up_style() {
-      if (this.picked_up) {
+      if (this.the_order["may_finish?"]) {
         return "success-color";
       } else {
         return "disabled-color";

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -192,12 +192,10 @@ export default {
   watch: {
     orderData() {
       this.the_order = { ...this.orderData };
-      console.log(this.the_order);
     },
   },
   mounted() {
     this.the_order = { ...this.orderData };
-    console.log(this.the_order);
   },
 };
 </script>

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -87,7 +87,6 @@ export default {
   inject: ["emitter"],
   methods: {
     confirm_shipped() {
-      this.emitter.emit("update_shipping_status", "shipping");
       const api = `${process.env.VUE_APP_API}/admin/orders/${this.the_order.id}/shipping_status`;
       const headers = { Authorization: Cookies.get("lemonToken") };
       const data = { shipping_status: "shipping" };
@@ -95,6 +94,7 @@ export default {
         .put(api, data, { headers })
         .then((response) => {
           this.the_order = response.data;
+          this.emitter.emit("updateOrderAllStatus");
         })
         .catch((error) => {
           if (error.response.status === 401) {

--- a/src/components/ShippingStatus.vue
+++ b/src/components/ShippingStatus.vue
@@ -15,16 +15,7 @@
       "
       style="width: 100px"
     />
-    <strong
-      v-if="
-        the_order['may_to_arrived?'] ||
-        the_order['may_to_picked_up?'] ||
-        the_order['may_finish?']
-      "
-      class="progress-color"
-    >
-      已發貨
-    </strong>
+    <strong v-else class="progress-color"> 已發貨 </strong>
 
     <i class="pi pi-arrow-right p-mx-1" :class="shipping_arrow_style"></i>
 
@@ -37,16 +28,7 @@
       "
       style="width: 100px"
     />
-    <strong
-      v-if="
-        the_order['may_to_shipping?'] ||
-        the_order['may_to_picked_up?'] ||
-        the_order['may_finish?']
-      "
-      :class="arrived_style"
-    >
-      已到達
-    </strong>
+    <strong v-else :class="arrived_style"> 已到達 </strong>
 
     <i class="pi pi-arrow-right p-mx-1" :class="arrived_arrow_style"></i>
 
@@ -60,21 +42,8 @@
       style="width: 100px"
     />
 
-    <strong
-      v-if="
-        the_order['may_to_shipping?'] ||
-        the_order['may_to_arrived?'] ||
-        the_order['may_finish?']
-      "
-      :class="picked_up_style"
-    >
-      已取貨
-    </strong>
-    <i
-      v-if="the_order['may_finish?']"
-      class="pi pi-check-circle success-color p-ml-1"
-    >
-    </i>
+    <strong v-else :class="picked_up_style"> 已取貨 </strong>
+    <i v-if="picked_up" class="pi pi-check-circle success-color p-ml-1"> </i>
   </div>
 </template>
 
@@ -165,13 +134,13 @@ export default {
     },
   },
   computed: {
-    in_preparation() {
-      return this.the_order.shipping_status === "in_preparation";
+    picked_up() {
+      return this.the_order.shipping_status === "picked_up";
     },
     arrived_style() {
       if (
-        this.the_order["may_to_picked_up?"] ||
-        this.the_order["may_finish?"]
+        this.the_order.shipping_status === "arrived" ||
+        this.the_order.shipping_status === "picked_up"
       ) {
         return "progress-color";
       } else {
@@ -180,9 +149,9 @@ export default {
     },
     shipping_arrow_style() {
       if (
-        this.the_order["may_to_arrived?"] ||
-        this.the_order["may_to_picked_up?"] ||
-        this.the_order["may_finish?"]
+        this.the_order.shipping_status === "shipping" ||
+        this.the_order.shipping_status === "arrived" ||
+        this.the_order.shipping_status === "picked_up"
       ) {
         return "arrow-color";
       } else {
@@ -191,8 +160,8 @@ export default {
     },
     arrived_arrow_style() {
       if (
-        this.the_order["may_to_picked_up?"] ||
-        this.the_order["may_finish?"]
+        this.the_order.shipping_status === "arrived" ||
+        this.the_order.shipping_status === "picked_up"
       ) {
         return "arrow-color";
       } else {
@@ -200,7 +169,7 @@ export default {
       }
     },
     picked_up_style() {
-      if (this.the_order["may_finish?"]) {
+      if (this.the_order.shipping_status === "picked_up") {
         return "success-color";
       } else {
         return "disabled-color";

--- a/src/components/SingleOrder.vue
+++ b/src/components/SingleOrder.vue
@@ -89,7 +89,7 @@
         </strong>
 
         <Button
-          v-if="outstanding && !canceled"
+          v-if="oneOrder['may_pay?'] && !canceled"
           @click="confirm_paid"
           label="確認付款"
           class="

--- a/src/components/SingleOrder.vue
+++ b/src/components/SingleOrder.vue
@@ -168,16 +168,24 @@ export default {
       }
     },
     confirm_paid() {
-      const api = `${process.env.VUE_APP_API}/admin/orders/${this.order.id}/payment_status`;
+      const api = `${process.env.VUE_APP_API}/admin/orders/${this.oneOrder.id}/payment_status`;
       const headers = { Authorization: Cookies.get("lemonToken") };
       const data = { payment_status: "paid" };
       axios
         .put(api, data, { headers })
         .then((response) => {
-          console.log(response);
+          this.oneOrder = response.data;
+          this.emitter.emit("updateOrderAllStatus");
         })
         .catch((error) => {
-          console.log(error.response);
+          if (error.response.status === 401) {
+            Cookies.remove("lemonToken");
+            this.showErrorToast("請重新登入");
+            this.$router.push("/entrance/login");
+          }
+        })
+        .finally(() => {
+          this.loading = false;
         });
     },
     caculateSubtotal(order) {

--- a/src/components/SingleOrder.vue
+++ b/src/components/SingleOrder.vue
@@ -103,7 +103,7 @@
       <OrderStatus :orderData="oneOrder" />
 
       <div class="p-col-12 p-lg-1 p-text-bold">物流狀態</div>
-      <ShippingStatus :orderData="oneOrder" :orderStatus="oneOrder.status" />
+      <ShippingStatus :orderData="oneOrder" />
     </div>
 
     <template #footer>

--- a/src/components/SingleOrder.vue
+++ b/src/components/SingleOrder.vue
@@ -5,7 +5,7 @@
     :breakpoints="{ '960px': '100vw' }"
     style="width: 60%"
   >
-    <h4 class="p-mt-0">成立時間 {{ order.created_at }}</h4>
+    <h4 class="p-mt-0">成立時間 {{ updateDateFormat(order.created_at) }}</h4>
     <div
       v-for="item in order.items"
       :key="item.id"
@@ -156,6 +156,11 @@ export default {
     },
   },
   methods: {
+    updateDateFormat(time) {
+      const oldStyle = new Date(Date.parse(time)).toLocaleString();
+      const newStyle = oldStyle.replace("/", "-").replace("/", "-");
+      return newStyle;
+    },
     groundText(ground_result) {
       if (ground_result === true) {
         return "磨粉";

--- a/src/components/SingleOrder.vue
+++ b/src/components/SingleOrder.vue
@@ -265,11 +265,6 @@ export default {
       return this.oneOrder.shipping_status === "in_preparation";
     },
   },
-  created() {
-    this.emitter.on("update_order_status", (current_order_status) => {
-      this.oneOrder.status = current_order_status;
-    });
-  },
 };
 </script>
 

--- a/src/components/SingleOrder.vue
+++ b/src/components/SingleOrder.vue
@@ -100,7 +100,7 @@
       </div>
 
       <div class="p-col-12 p-lg-1 p-text-bold">訂單狀態</div>
-      <OrderStatus :orderStatus="oneOrder.status" />
+      <OrderStatus :orderData="oneOrder" />
 
       <div class="p-col-12 p-lg-1 p-text-bold">物流狀態</div>
       <ShippingStatus
@@ -132,6 +132,8 @@
 <script>
 import ShippingStatus from "@/components/ShippingStatus.vue";
 import OrderStatus from "@/components/OrderStatus.vue";
+import axios from "axios";
+import Cookies from "js-cookie";
 
 export default {
   data() {
@@ -169,7 +171,17 @@ export default {
       }
     },
     confirm_paid() {
-      this.oneOrder.payment_status = "paid";
+      const api = `${process.env.VUE_APP_API}/admin/orders/${this.order.id}/payment_status`;
+      const headers = { Authorization: Cookies.get("lemonToken") };
+      const data = { payment_status: "paid" };
+      axios
+        .put(api, data, { headers })
+        .then((response) => {
+          console.log(response);
+        })
+        .catch((error) => {
+          console.log(error.response);
+        });
     },
     caculateSubtotal(order) {
       return order.items.reduce((acc, current_item) => {

--- a/src/components/SingleOrder.vue
+++ b/src/components/SingleOrder.vue
@@ -258,9 +258,6 @@ export default {
     },
   },
   created() {
-    this.emitter.on("update_shipping_status", (current_shipping_status) => {
-      this.oneOrder.shipping_status = current_shipping_status;
-    });
     this.emitter.on("update_order_status", (current_order_status) => {
       this.oneOrder.status = current_order_status;
     });

--- a/src/components/SingleOrder.vue
+++ b/src/components/SingleOrder.vue
@@ -103,10 +103,7 @@
       <OrderStatus :orderData="oneOrder" />
 
       <div class="p-col-12 p-lg-1 p-text-bold">物流狀態</div>
-      <ShippingStatus
-        :shippingStatus="oneOrder.shipping_status"
-        :orderStatus="oneOrder.status"
-      />
+      <ShippingStatus :orderData="oneOrder" :orderStatus="oneOrder.status" />
     </div>
 
     <template #footer>

--- a/src/components/SingleOrder.vue
+++ b/src/components/SingleOrder.vue
@@ -110,7 +110,7 @@
       <div class="p-d-flex p-jc-end">
         <Button
           :disabled="!oneOrder['may_cancel?']"
-          @click.prevent="cancelTheOreder()"
+          @click.prevent="cancelTheOreder"
           label="取消訂單"
           icon="pi pi-times"
           class="p-button-danger p-ml-3"
@@ -213,7 +213,6 @@ export default {
       axios
         .put(api, data, { headers })
         .then((response) => {
-          console.log(response);
           this.oneOrder = response.data;
           this.emitter.emit("updateOrderAllStatus");
         })

--- a/src/components/UserOrderStatus.vue
+++ b/src/components/UserOrderStatus.vue
@@ -50,7 +50,7 @@ export default {
   inject: ["emitter"],
   methods: {
     finishedOrder() {
-      this.emitter.emit("update_order_status", "finished");
+      
     },
   },
   computed: {

--- a/src/components/UserOrderStatus.vue
+++ b/src/components/UserOrderStatus.vue
@@ -11,7 +11,7 @@
     <i :class="pendingAndConfirmedArrowStyle" class="pi pi-arrow-right p-mx-1">
     </i>
     <Button
-      :disabled="!(pickedUp && paid)"
+      :disabled="!the_order['may_finish?']"
       @click="finishedOrder"
       v-if="confirmed"
       label="完成訂單"
@@ -36,17 +36,6 @@ export default {
     };
   },
   props: {
-    shippingStatus: {
-      type: String,
-      default() {
-        return;
-      },
-    },
-    paymentStatus: {
-      type: String,
-      default() {
-        return;
-      },
     orderData: {
       type: Object,
     },
@@ -77,22 +66,22 @@ export default {
   },
   computed: {
     pending() {
-      return this.orderStatus === "pending";
+      return this.the_order.status === "pending";
     },
     confirmed() {
-      return this.orderStatus === "confirmed";
+      return this.the_order.status === "confirmed";
     },
     pickedUp() {
-      return this.shippingStatus === "picked_up";
+      return this.the_order.shipping_status === "picked_up";
     },
     finished() {
-      return this.orderStatus === "finished";
+      return this.the_order.status === "finished";
     },
     canceled() {
-      return this.orderStatus === "canceled";
+      return this.the_order.status === "canceled";
     },
     paid() {
-      return this.paymentStatus === "paid";
+      return this.the_order.payment_status === "paid";
     },
     pendingAndConfirmedArrowStyle() {
       if (this.confirmed || this.finished) {

--- a/src/components/UserOrderStatus.vue
+++ b/src/components/UserOrderStatus.vue
@@ -108,12 +108,10 @@ export default {
   watch: {
     orderData() {
       this.the_order = { ...this.orderData };
-      console.log(this.the_order);
     },
   },
   mounted() {
     this.the_order = { ...this.orderData };
-    console.log(this.the_order);
   },
 };
 </script>

--- a/src/components/UserShippingStatus.vue
+++ b/src/components/UserShippingStatus.vue
@@ -22,36 +22,32 @@
 
 <script>
 export default {
+  data() {
+    return {
+      the_order: {},
+    };
+  },
   props: {
-    shippingStatus: {
-      type: String,
-      default() {
-        return;
-      },
-    },
-    orderStatus: {
-      type: String,
-      default() {
-        return;
-      },
+    orderData: {
+      type: Object,
     },
   },
   inject: ["emitter"],
   computed: {
     inPreparation() {
-      return this.shippingStatus === "in_preparation";
+      return this.the_order.shipping_status === "in_preparation";
     },
     shipping() {
-      return this.shippingStatus === "shipping";
+      return this.the_order.shipping_status === "shipping";
     },
     arrived() {
-      return this.shippingStatus === "arrived";
+      return this.the_order.shipping_status === "arrived";
     },
     pickedUp() {
-      return this.shippingStatus === "picked_up";
+      return this.the_order.shipping_status === "picked_up";
     },
     canceled() {
-      return this.orderStatus === "canceled";
+      return this.the_order.status === "canceled";
     },
     inPreparationArrowStyle() {
       if (this.shipping || this.arrived || this.pickedUp) {
@@ -95,6 +91,14 @@ export default {
         return "disabled-color";
       }
     },
+  },
+  watch: {
+    orderData() {
+      this.the_order = { ...this.orderData };
+    },
+  },
+  mounted() {
+    this.the_order = { ...this.orderData };
   },
 };
 </script>

--- a/src/components/UserSingleOrder.vue
+++ b/src/components/UserSingleOrder.vue
@@ -90,11 +90,7 @@
       </div>
 
       <div class="p-col-12 p-lg-1 p-text-bold">訂單狀態</div>
-      <UserOrderStatus
-        :orderStatus="oneOrder.status"
-        :shippingStatus="oneOrder.shipping_status"
-        :paymentStatus="oneOrder.payment_status"
-      />
+      <UserOrderStatus :orderData="oneOrder" />
 
       <div class="p-col-12 p-lg-1 p-text-bold">物流狀態</div>
       <UserShippingStatus

--- a/src/components/UserSingleOrder.vue
+++ b/src/components/UserSingleOrder.vue
@@ -5,7 +5,7 @@
     :breakpoints="{ '960px': '100vw' }"
     style="width: 60%"
   >
-    <h4 class="p-mt-0">成立時間 {{ order.created_at }}</h4>
+    <h4 class="p-mt-0">成立時間 {{ updateDateFormat(order.created_at) }}</h4>
     <div
       v-for="item in order.items"
       :key="item.id"
@@ -150,6 +150,11 @@ export default {
     },
   },
   methods: {
+    updateDateFormat(time) {
+      const oldStyle = new Date(Date.parse(time)).toLocaleString();
+      const newStyle = oldStyle.replace("/", "-").replace("/", "-");
+      return newStyle;
+    },
     groundText(ground_result) {
       if (ground_result === true) {
         return "磨粉";

--- a/src/components/UserSingleOrder.vue
+++ b/src/components/UserSingleOrder.vue
@@ -232,9 +232,6 @@ export default {
     },
   },
   created() {
-    this.emitter.on("update_shipping_status", (current_shipping_status) => {
-      this.oneOrder.shipping_status = current_shipping_status;
-    });
     this.emitter.on("update_order_status", (current_order_status) => {
       this.oneOrder.status = current_order_status;
     });

--- a/src/components/UserSingleOrder.vue
+++ b/src/components/UserSingleOrder.vue
@@ -106,7 +106,7 @@
     <template #footer>
       <div class="p-d-flex p-jc-end">
         <Button
-          :disabled="!(outstanding && inPreparation && (pending || confirmed))"
+          :disabled="!oneOrder['may_cancel?']"
           @click.prevent="cancelTheOrder"
           label="取消訂單"
           icon="pi pi-times"

--- a/src/components/UserSingleOrder.vue
+++ b/src/components/UserSingleOrder.vue
@@ -93,10 +93,7 @@
       <UserOrderStatus :orderData="oneOrder" />
 
       <div class="p-col-12 p-lg-1 p-text-bold">物流狀態</div>
-      <UserShippingStatus
-        :shippingStatus="oneOrder.shipping_status"
-        :orderStatus="oneOrder.status"
-      />
+      <UserShippingStatus :orderData="oneOrder" />
     </div>
 
     <template #footer>

--- a/src/components/UserSingleOrder.vue
+++ b/src/components/UserSingleOrder.vue
@@ -231,11 +231,6 @@ export default {
       return this.oneOrder.shipping_status === "in_preparation";
     },
   },
-  created() {
-    this.emitter.on("update_order_status", (current_order_status) => {
-      this.oneOrder.status = current_order_status;
-    });
-  },
 };
 </script>
 

--- a/src/components/UserSingleOrder.vue
+++ b/src/components/UserSingleOrder.vue
@@ -126,6 +126,8 @@
 <script>
 import UserShippingStatus from "@/components/UserShippingStatus.vue";
 import UserOrderStatus from "@/components/UserOrderStatus.vue";
+import axios from "axios";
+import Cookies from "js-cookie";
 
 export default {
   data() {
@@ -181,7 +183,25 @@ export default {
       this.isOpen = false;
     },
     cancelTheOrder() {
-      this.oneOrder.status = "canceled";
+      const api = `${process.env.VUE_APP_API}/admin/orders/${this.oneOrder.id}/status`;
+      const headers = { Authorization: Cookies.get("lemonToken") };
+      const data = { status: "canceled" };
+      axios
+        .put(api, data, { headers })
+        .then((response) => {
+          this.oneOrder = response.data;
+          this.emitter.emit("updateUserOrderAllStatus");
+        })
+        .catch((error) => {
+          if (error.response.status === 401) {
+            Cookies.remove("lemonToken");
+            this.showErrorToast("請重新登入");
+            this.$router.push("/entrance/login");
+          }
+        })
+        .finally(() => {
+          this.loading = false;
+        });
     },
   },
   inject: ["emitter"],

--- a/src/views/Manager/Orders.vue
+++ b/src/views/Manager/Orders.vue
@@ -107,6 +107,7 @@ export default {
     };
   },
   components: { SingleOrder },
+  inject: ["emitter"],
   methods: {
     getOrders() {
       const api = `${process.env.VUE_APP_API}/admin/orders`;
@@ -207,6 +208,9 @@ export default {
   },
   created() {
     this.getOrders();
+    this.emitter.on("updateOrderStatus", () => {
+      this.getOrders();
+    });
   },
 };
 </script>

--- a/src/views/Manager/Orders.vue
+++ b/src/views/Manager/Orders.vue
@@ -208,7 +208,7 @@ export default {
   },
   created() {
     this.getOrders();
-    this.emitter.on("updateOrderStatus", () => {
+    this.emitter.on("updateOrderAllStatus", () => {
       this.getOrders();
     });
   },

--- a/src/views/Manager/Orders.vue
+++ b/src/views/Manager/Orders.vue
@@ -186,13 +186,11 @@ export default {
     },
 
     getTheOrder(id) {
-      console.log(id);
       const api = `${process.env.VUE_APP_API}/admin/orders/${id}`;
       const headers = { Authorization: Cookies.get("lemonToken") };
       axios
         .get(api, { headers })
         .then((response) => {
-          console.log(response);
           this.order = { ...response.data };
         })
         .catch((error) => {

--- a/src/views/Manager/Orders.vue
+++ b/src/views/Manager/Orders.vue
@@ -211,6 +211,9 @@ export default {
     this.emitter.on("updateOrderAllStatus", () => {
       this.getOrders();
     });
+    this.emitter.on("updateCancelBtnStatus", (id) => {
+      this.getTheOrder(id);
+    });
   },
 };
 </script>

--- a/src/views/Manager/Orders.vue
+++ b/src/views/Manager/Orders.vue
@@ -19,7 +19,7 @@
     stateKey="dt-state-demo-local"
     v-model:selection="orders.items"
     selectionMode="single"
-    @rowSelect="openTheOrder(orders.items)"
+    @rowSelect="getTheOrder(orders.items.id)"
   >
     <template #header>
       <div class="p-text-center">
@@ -109,7 +109,7 @@ export default {
   components: { SingleOrder },
   methods: {
     getOrders() {
-      const api = `${process.env.VUE_APP_API}/users/orders`;
+      const api = `${process.env.VUE_APP_API}/admin/orders`;
       const headers = { Authorization: Cookies.get("lemonToken") };
       axios
         .get(api, { headers })
@@ -184,8 +184,27 @@ export default {
           return "已取貨";
       }
     },
-    openTheOrder(the_order) {
-      this.order = { ...the_order };
+
+    getTheOrder(id) {
+      console.log(id);
+      const api = `${process.env.VUE_APP_API}/admin/orders/${id}`;
+      const headers = { Authorization: Cookies.get("lemonToken") };
+      axios
+        .get(api, { headers })
+        .then((response) => {
+          console.log(response);
+          this.order = { ...response.data };
+        })
+        .catch((error) => {
+          if (error.response.status === 401) {
+            Cookies.remove("lemonToken");
+            this.showErrorToast("請重新登入");
+            this.$router.push("/entrance/login");
+          }
+        })
+        .finally(() => {
+          this.loading = false;
+        });
     },
   },
   created() {


### PR DESCRIPTION
https://kakas-redmine.herokuapp.com/issues/1036

## 將管理者、使用者的訂單，分別三種狀態【付款狀態】【訂單狀態】【物流狀態】個別串接 API
### ★ 管理者 : /admin/orders
![image](https://user-images.githubusercontent.com/77562017/177684189-346ff8bf-ffd2-4ebb-82c9-89a9ec5a95e7.png)
### ★ 串接個別按鈕的API，並將對應該顯示的UI顯示在畫面上
![image](https://user-images.githubusercontent.com/77562017/177684537-76a778c8-39f8-49c4-8f20-a2f4ba79bef4.png)
![image](https://user-images.githubusercontent.com/77562017/177684619-3751efea-5263-459a-9540-c2da23ec2e68.png)
### ★ 使用者 : /orders
![image](https://user-images.githubusercontent.com/77562017/177684852-a868de1d-fbd3-4459-aa7d-4eff6a937ea6.png)
### ★ 串接完成淡定按鈕的API，並將對應該顯示的UI顯示在畫面上
![image](https://user-images.githubusercontent.com/77562017/177684934-a01007d5-1634-4dfa-88b8-10d7dfe15a5c.png)
![image](https://user-images.githubusercontent.com/77562017/177684984-c48d402f-957e-4dae-9d85-1543be91a233.png)
